### PR TITLE
🧪 test: add test coverage for get_ffmpeg_path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,3 +23,9 @@ packages = ["alenia_porter"]
 
 [tool.setuptools.package-data]
 alenia_porter = ["py.typed", "assets/images/*", "assets/locales/*", "assets/themes/*"]
+
+[dependency-groups]
+dev = [
+    "pytest>=9.1.1",
+    "pytest-mock>=3.15.1",
+]

--- a/tests/test_porter.py
+++ b/tests/test_porter.py
@@ -1,0 +1,75 @@
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+
+# Assuming resource_path is a context manager, we need to mock it properly
+from alenia_porter.porter import get_ffmpeg_path
+
+def test_get_ffmpeg_path_posix(mocker):
+    """Test get_ffmpeg_path on non-Windows systems."""
+    mocker.patch("alenia_porter.porter.os.name", "posix")
+
+    assert get_ffmpeg_path() == "ffmpeg"
+
+
+def test_get_ffmpeg_path_nt_exists_lower(mocker):
+    """Test get_ffmpeg_path on Windows when ffmpeg.exe exists."""
+    mocker.patch("alenia_porter.porter.os.name", "nt")
+
+    mock_resource_path = mocker.patch("alenia_porter.porter.resource_path")
+    mock_context_manager = MagicMock()
+    mock_resource_path.return_value = mock_context_manager
+    mock_context_manager.__enter__.return_value = "C:\\path\\to\\bin\\ffmpeg.exe"
+
+    mock_path_exists = mocker.patch("alenia_porter.porter.os.path.exists")
+    mock_path_exists.return_value = True
+
+    result = get_ffmpeg_path()
+
+    assert result == "C:\\path\\to\\bin\\ffmpeg.exe"
+    mock_path_exists.assert_called_once_with("C:\\path\\to\\bin\\ffmpeg.exe")
+
+
+def test_get_ffmpeg_path_nt_exists_upper(mocker):
+    """Test get_ffmpeg_path on Windows when only ffmpeg.EXE exists."""
+    mocker.patch("alenia_porter.porter.os.name", "nt")
+
+    mock_resource_path = mocker.patch("alenia_porter.porter.resource_path")
+    mock_context_manager1 = MagicMock()
+    mock_context_manager2 = MagicMock()
+    mock_resource_path.side_effect = [mock_context_manager1, mock_context_manager2]
+
+    mock_context_manager1.__enter__.return_value = "C:\\path\\to\\bin\\ffmpeg.exe"
+    mock_context_manager2.__enter__.return_value = "C:\\path\\to\\bin\\ffmpeg.EXE"
+
+    mock_path_exists = mocker.patch("alenia_porter.porter.os.path.exists")
+    # First call (ffmpeg.exe) is False, second call (ffmpeg.EXE) is True
+    mock_path_exists.side_effect = [False, True]
+
+    result = get_ffmpeg_path()
+
+    assert result == "C:\\path\\to\\bin\\ffmpeg.EXE"
+    assert mock_path_exists.call_count == 2
+    mock_path_exists.assert_any_call("C:\\path\\to\\bin\\ffmpeg.exe")
+    mock_path_exists.assert_any_call("C:\\path\\to\\bin\\ffmpeg.EXE")
+
+
+def test_get_ffmpeg_path_nt_not_exists(mocker):
+    """Test get_ffmpeg_path on Windows when neither ffmpeg.exe nor ffmpeg.EXE exists."""
+    mocker.patch("alenia_porter.porter.os.name", "nt")
+
+    mock_resource_path = mocker.patch("alenia_porter.porter.resource_path")
+    mock_context_manager1 = MagicMock()
+    mock_context_manager2 = MagicMock()
+    mock_resource_path.side_effect = [mock_context_manager1, mock_context_manager2]
+
+    mock_context_manager1.__enter__.return_value = "C:\\path\\to\\bin\\ffmpeg.exe"
+    mock_context_manager2.__enter__.return_value = "C:\\path\\to\\bin\\ffmpeg.EXE"
+
+    mock_path_exists = mocker.patch("alenia_porter.porter.os.path.exists")
+    mock_path_exists.return_value = False
+
+    result = get_ffmpeg_path()
+
+    assert result == "ffmpeg.exe"
+    assert mock_path_exists.call_count == 2

--- a/uv.lock
+++ b/uv.lock
@@ -6,3 +6,90 @@ requires-python = ">=3.13"
 name = "alenia-porter"
 version = "5.8.0"
 source = { editable = "." }
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-mock" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=9.1.1" },
+    { name = "pytest-mock", specifier = ">=3.15.1" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pytest-mock"
+version = "3.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
+]


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR addresses the missing tests for `get_ffmpeg_path` in `src/alenia_porter/porter.py`.

📊 **Coverage:** What scenarios are now tested
The new tests cover:
- Non-Windows systems (`os.name == "posix"`) returning `"ffmpeg"`.
- Windows systems where `ffmpeg.exe` exists in the local bin resource.
- Windows systems where `ffmpeg.EXE` exists in the local bin resource but not lowercase.
- Windows systems where neither binary exists, falling back to `"ffmpeg.exe"`.

✨ **Result:** The improvement in test coverage
Test coverage is significantly improved by providing unit tests that mock the OS environment, allowing developers to safely modify this path resolution code in the future without regressions.

---
*PR created automatically by Jules for task [11171102562829065647](https://jules.google.com/task/11171102562829065647) started by @kaia-alina*