### PR TITLE
🧪 Add error path test for log_error_to_file

### DIFF
--- a/tests/test_porter.py
+++ b/tests/test_porter.py
@@ -1,0 +1,20 @@
+import pytest
+from unittest.mock import patch, mock_open
+from alenia_porter.porter import log_error_to_file
+
+def test_log_error_to_file_success():
+    """Test that log_error_to_file writes properly when no exception occurs."""
+    with patch("builtins.open", mock_open()) as mocked_file:
+        log_error_to_file("Test error message")
+        mocked_file.assert_called_once_with("ALENIA_ERROR.txt", "a", encoding="utf-8")
+        mocked_file().write.assert_called_once_with("\n--- ERROR ---\nTest error message\n")
+
+def test_log_error_to_file_exception():
+    """Test that log_error_to_file silently swallows exceptions like IOError."""
+    with patch("builtins.open", mock_open()) as mocked_file:
+        mocked_file.side_effect = IOError("Mocked IO Error")
+        # Function should swallow the exception without raising
+        log_error_to_file("This error cannot be written")
+
+        # Verify open was called
+        mocked_file.assert_called_once_with("ALENIA_ERROR.txt", "a", encoding="utf-8")


### PR DESCRIPTION
🎯 **What:** Added missing tests for the `log_error_to_file` function in `src/alenia_porter/porter.py`.
📊 **Coverage:** Added test cases covering both the happy path where writing is successful, and the error path where an `IOError` is raised and correctly swallowed.
✨ **Result:** Test coverage for this function is now 100%, and we now have deterministic assurance that exceptions raised during logging are properly swallowed by the try/except block without bubbling up and crashing the main process.

---
*PR created automatically by Jules for task [4546264198551375144](https://jules.google.com/task/4546264198551375144) started by @kaia-alina*