### PR TITLE
⚡ Bolt: Optimize directory traversal for media conversion

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2023-10-25 - Redundant Generator Traversal
+**Learning:** In standard library components or specific scripts acting on file systems, generating file lists via I/O bound logic like `os.scandir` combined with generators can cause double-iteration bottlenecks if the generator must be traversed twice (e.g., once to determine total count, again to assign workloads).
+**Action:** Immediately look for list conversion (`list(generator)`) when counting `len()` is needed prior to consuming the data inside concurrent executors or loops, particularly for I/O operations, to prevent redundant disk accesses.

--- a/src/alenia_porter/porter.py
+++ b/src/alenia_porter/porter.py
@@ -339,10 +339,9 @@ def convert_media(input_directory, target_audio_format, progress_update_callback
         video_extensions = (".mp4", ".mkv", ".webm", ".avi", ".mov", ".wmv", ".flv", ".m4v", ".mpg", ".mpeg", ".m2v", ".3gp", ".3g2", ".ts", ".m2ts", ".vob", ".ogv", ".asf", ".divx")
         image_extensions = (".png", ".jpg", ".jpeg", ".bmp", ".tga", ".webp")
         
-        total_files_count = 0
-        file_generator = stream_files(input_directory, input_directory, audio_extensions, video_extensions, image_extensions)
-        for _ in file_generator:
-            total_files_count += 1
+        # BOLT OPTIMIZATION: Cache file generator to list to prevent second redundant disk read operation.
+        file_list = list(stream_files(input_directory, input_directory, audio_extensions, video_extensions, image_extensions))
+        total_files_count = len(file_list)
 
         if total_files_count == 0:
             completion_callback(0, input_directory, 0, 0)
@@ -367,7 +366,6 @@ def convert_media(input_directory, target_audio_format, progress_update_callback
         total_final_size = 0
         processed_files_count = 0
 
-        file_generator = stream_files(input_directory, input_directory, audio_extensions, video_extensions, image_extensions)
         max_workers = max(1, os.cpu_count() - 1)
         with concurrent.futures.ProcessPoolExecutor(max_workers=max_workers) as executor:
             futures = {
@@ -380,7 +378,7 @@ def convert_media(input_directory, target_audio_format, progress_update_callback
                     image_output_directory,
                     ffmpeg_executable_path,
                     subprocess_creation_flags
-                ): file_info for file_info in file_generator
+                ): file_info for file_info in file_list
             }
 
             for future in concurrent.futures.as_completed(futures):


### PR DESCRIPTION
💡 What: Caches the `stream_files` generator results into a list to prevent redundant directory traversal operations during file counting and task submission.
🎯 Why: Previously, the script was performing two separate recursive directory traversals (`os.scandir`)—once to count the files and a second time to feed the `ProcessPoolExecutor`. This resulted in an unnecessary read sequence on the disk.
📊 Impact: Halves the disk I/O cost of gathering files before compression starts, leading to significantly faster initial processing times, especially noticeable on large project folders or slow storage systems.
🔬 Measurement: Verify by executing conversion on a directory with thousands of files and noting the time taken before the conversion tasks actively start logging output.

---
*PR created automatically by Jules for task [3669659727339923747](https://jules.google.com/task/3669659727339923747) started by @kaia-alina*